### PR TITLE
Release 0.2.1

### DIFF
--- a/MC-PBR-Pipeline/ImageProcessors/PixelProcessor.cs
+++ b/MC-PBR-Pipeline/ImageProcessors/PixelProcessor.cs
@@ -42,7 +42,7 @@ namespace McPbrPipeline.ImageProcessors
                 AlphaActions = new List<PixelAction>();
             }
 
-            public Options Append(ColorChannel color, PixelAction action = null)
+            public Options Append(ColorChannel color, PixelAction action)
             {
                 switch (color) {
                     case ColorChannel.Red:
@@ -62,7 +62,7 @@ namespace McPbrPipeline.ImageProcessors
                 return this;
             }
 
-            public Options SetPost(ColorChannel color, PixelAction action = null)
+            public Options SetPost(ColorChannel color, PixelAction action)
             {
                 switch (color) {
                     case ColorChannel.Red:

--- a/MC-PBR-Pipeline/Internal/Input/PbrProperties.cs
+++ b/MC-PBR-Pipeline/Internal/Input/PbrProperties.cs
@@ -35,26 +35,27 @@ namespace McPbrPipeline.Internal.Input
         public byte? NormalValueY => Get<byte?>("normal.value.y");
         public byte? NormalValueZ => Get<byte?>("normal.value.z");
 
-        public string SpecularTexture => Get<string>("specular.texture");
-
-        public string EmissiveTexture => Get<string>("emissive.texture");
-        public float EmissiveScale => Get("emissive.scale", 1f);
-        public byte? EmissiveValue => Get<byte?>("emissive.value");
-
         public string OcclusionTexture => Get<string>("occlusion.texture");
         public byte? OcclusionValue => Get<byte?>("occlusion.value");
+        public float OcclusionScale => Get("occlusion.scale", 1f);
+
+        public string SpecularTexture => Get<string>("specular.texture");
 
         public string SmoothTexture => Get<string>("smooth.texture");
-        public float SmoothScale => Get("smooth.scale", 1f);
         public byte? SmoothValue => Get<byte?>("smooth.value");
+        public float SmoothScale => Get("smooth.scale", 1f);
 
         public string RoughTexture => Get<string>("rough.texture");
-        public float RoughScale => Get("rough.scale", 1f);
         public byte? RoughValue => Get<byte?>("rough.value");
+        public float RoughScale => Get("rough.scale", 1f);
 
         public string MetalTexture => Get<string>("metal.texture");
         public float MetalScale => Get("metal.scale", 1f);
         public byte? MetalValue => Get<byte?>("metal.value");
+
+        public string EmissiveTexture => Get<string>("emissive.texture");
+        public byte? EmissiveValue => Get<byte?>("emissive.value");
+        public float EmissiveScale => Get("emissive.scale", 1f);
 
         public byte? PorosityValue => Get<byte?>("porosity.value");
 

--- a/MC-PBR-Pipeline/Internal/Textures/TextureBuilder.cs
+++ b/MC-PBR-Pipeline/Internal/Textures/TextureBuilder.cs
@@ -61,42 +61,22 @@ namespace McPbrPipeline.Internal.Textures
             var isOutputEmissiveInverse = EncodingChannel.Is(outputChannel, EncodingChannel.EmissiveInverse);
             if (isOutputEmissiveInverse) filterOptions.SetPost(color, filter.Invert);
 
-            if (byte.TryParse(outputChannel, out var value)) {
+            if (byte.TryParse(outputChannel, out var value))
                 SetSourceColor(color, value);
 
-                //if (string.Equals(EncodingChannel.Height, outputChannel, StringComparison.InvariantCultureIgnoreCase))
-                //    filterOptions.SetPost(color, filter.Invert);
-
-                //if (string.Equals(EncodingChannel.EmissiveClipped, outputChannel, StringComparison.InvariantCultureIgnoreCase))
-                //    filterOptions.SetPost(color, filter.EmissiveToEmissiveClipped);
-
-                //if (string.Equals(EncodingChannel.EmissiveInverse, outputChannel, StringComparison.InvariantCultureIgnoreCase))
-                //    filterOptions.SetPost(color, filter.Invert);
-            }
-
-            else if (filter.TryGetChannelValue(outputChannel, out value)) {
+            else if (filter.TryGetChannelValue(outputChannel, out value))
                 SetSourceColor(color, value);
-
-                //if (string.Equals(EncodingChannel.Height, outputChannel, StringComparison.InvariantCultureIgnoreCase))
-                //    filterOptions.SetPost(color, filter.Invert);
-
-                //if (string.Equals(EncodingChannel.EmissiveClipped, outputChannel, StringComparison.InvariantCultureIgnoreCase))
-                //    filterOptions.SetPost(color, filter.EmissiveToEmissiveClipped);
-
-                //if (string.Equals(EncodingChannel.EmissiveInverse, outputChannel, StringComparison.InvariantCultureIgnoreCase))
-                //    filterOptions.SetPost(color, filter.Invert);
-            }
 
             else if (graph.TryGetSources(outputChannel, out var sourceList)) {
                 foreach (var source in sourceList)
                     optionsMap.GetOrCreate(source.Tag, NewOptions)
                         .Set(source.Channel, color);
 
-                if (isOutputHeight) filterOptions.Append(color, filter.Invert); //.SetPost(color, filter.Invert);
+                if (isOutputHeight) filterOptions.Append(color, filter.Invert);
 
-                if (isOutputEmissiveClipped) filterOptions.Append(color, filter.EmissiveClippedToEmissive); //.SetPost(color, filter.Invert);
+                if (isOutputEmissiveClipped) filterOptions.Append(color, filter.EmissiveClippedToEmissive);
 
-                if (isOutputEmissiveInverse) filterOptions.Append(color, filter.Invert); //.SetPost(color, filter.Invert);
+                if (isOutputEmissiveInverse) filterOptions.Append(color, filter.Invert);
             }
 
             else {
@@ -129,8 +109,6 @@ namespace McPbrPipeline.Internal.Textures
                 if (isOutputEmissiveClipped && graph.TryGetSources(EncodingChannel.Emissive, out sourceList)) {
                     foreach (var source in sourceList)
                         optionsMap.GetOrCreate(source.Tag, NewOptions).Set(source.Channel, color);
-
-                    //filterOptions.SetPost(color, filter.EmissiveToEmissiveClipped);
                 }
 
                 // EmissiveClipped > Emissive
@@ -145,9 +123,6 @@ namespace McPbrPipeline.Internal.Textures
                 if (isOutputEmissiveInverse && graph.TryGetSources(EncodingChannel.Emissive, out sourceList)) {
                     foreach (var source in sourceList)
                         optionsMap.GetOrCreate(source.Tag, NewOptions).Set(source.Channel, color);
-
-                    // TODO: Not sure if this is redundant?
-                    //filterOptions.Append(color, filter.Invert);
                 }
 
                 // EmissiveInv > Emissive

--- a/MC-PBR-Pipeline/Internal/Textures/TextureBuilder.cs
+++ b/MC-PBR-Pipeline/Internal/Textures/TextureBuilder.cs
@@ -49,16 +49,20 @@ namespace McPbrPipeline.Internal.Textures
             if (outputChannel == null) return;
 
             var isOutputHeight = EncodingChannel.Is(outputChannel, EncodingChannel.Height);
-            if (isOutputHeight) filterOptions.SetPost(color, filter.Invert);
-
-            var isSmooth = string.Equals(outputChannel, EncodingChannel.Smooth, StringComparison.InvariantCultureIgnoreCase);
-            var isSmooth2 = string.Equals(outputChannel, EncodingChannel.PerceptualSmooth, StringComparison.InvariantCultureIgnoreCase);
+            var isOutputNormalZ = EncodingChannel.Is(outputChannel, EncodingChannel.NormalZ);
+            var isOutputSmooth = EncodingChannel.Is(outputChannel, EncodingChannel.Smooth);
+            var isOutputSmooth2 = EncodingChannel.Is(outputChannel, EncodingChannel.PerceptualSmooth);
+            var isOutputRough = EncodingChannel.Is(outputChannel, EncodingChannel.Rough);
+            var isOutputOcclusion = EncodingChannel.Is(outputChannel, EncodingChannel.Occlusion);
             var isOutputEmissive = EncodingChannel.Is(outputChannel, EncodingChannel.Emissive);
-
             var isOutputEmissiveClipped = EncodingChannel.Is(outputChannel, EncodingChannel.EmissiveClipped);
-            if (isOutputEmissiveClipped) filterOptions.SetPost(color, filter.EmissiveToEmissiveClipped);
-
             var isOutputEmissiveInverse = EncodingChannel.Is(outputChannel, EncodingChannel.EmissiveInverse);
+
+            if (isOutputHeight) filterOptions.SetPost(color, filter.Invert);
+            if (isOutputOcclusion) filterOptions.SetPost(color, filter.Invert);
+            if (isOutputRough) filterOptions.SetPost(color, filter.Invert);
+            if (isOutputSmooth2) filterOptions.SetPost(color, filter.SmoothToPerceptualSmooth);
+            if (isOutputEmissiveClipped) filterOptions.SetPost(color, filter.EmissiveToEmissiveClipped);
             if (isOutputEmissiveInverse) filterOptions.SetPost(color, filter.Invert);
 
             if (byte.TryParse(outputChannel, out var value))
@@ -68,69 +72,57 @@ namespace McPbrPipeline.Internal.Textures
                 SetSourceColor(color, value);
 
             else if (graph.TryGetSources(outputChannel, out var sourceList)) {
+                PixelAction action = null;
+                if (isOutputHeight) action = filter.Invert;
+                if (isOutputOcclusion) action = filter.Invert;
+                if (isOutputRough) action = filter.Invert;
+                if (isOutputSmooth2) action = filter.PerceptualSmoothToSmooth;
+                if (isOutputEmissiveClipped) action = filter.EmissiveClippedToEmissive;
+                if (isOutputEmissiveInverse) action = filter.Invert;
+
                 foreach (var source in sourceList)
                     optionsMap.GetOrCreate(source.Tag, NewOptions)
-                        .Set(source.Channel, color);
-
-                if (isOutputHeight) filterOptions.Append(color, filter.Invert);
-
-                if (isOutputEmissiveClipped) filterOptions.Append(color, filter.EmissiveClippedToEmissive);
-
-                if (isOutputEmissiveInverse) filterOptions.Append(color, filter.Invert);
+                        .Set(source.Channel, color, action);
             }
 
             else {
                 // restore normal-z
-                if (string.Equals(outputChannel, EncodingChannel.NormalZ, StringComparison.InvariantCultureIgnoreCase)) restoreNormalZ = true;
+                if (isOutputNormalZ) restoreNormalZ = true;
+
+                // Smooth > *
+                if ((isOutputRough || isOutputSmooth2) && graph.TryGetSources(EncodingChannel.Smooth, out sourceList)) {
+                    foreach (var source in sourceList)
+                        optionsMap.GetOrCreate(source.Tag, NewOptions).Set(source.Channel, color);
+                }
+
+                // Rough > Smooth
+                if ((isOutputSmooth || isOutputSmooth2) && graph.TryGetSources(EncodingChannel.Rough, out sourceList)) {
+                    foreach (var source in sourceList)
+                        optionsMap.GetOrCreate(source.Tag, NewOptions).Set(source.Channel, color, filter.Invert);
+                }
 
                 // Smooth2 > Smooth
-                if (isSmooth2 && graph.TryGetSources(EncodingChannel.Smooth, out sourceList)) {
+                if ((isOutputRough || isOutputSmooth) && graph.TryGetSources(EncodingChannel.PerceptualSmooth, out sourceList)) {
                     foreach (var source in sourceList)
-                        optionsMap.GetOrCreate(source.Tag, NewOptions).Set(source.Channel, color);
-
-                    filterOptions.Append(color, filter.PerceptualSmoothToSmooth);
+                        optionsMap.GetOrCreate(source.Tag, NewOptions).Set(source.Channel, color, filter.PerceptualSmoothToSmooth);
                 }
 
-                // Smooth > Smooth2
-                if (isSmooth && graph.TryGetSources(EncodingChannel.PerceptualSmooth, out sourceList)) {
-                    foreach (var source in sourceList)
-                        optionsMap.GetOrCreate(source.Tag, NewOptions).Set(source.Channel, color);
-
-                    filterOptions.SetPost(color, filter.SmoothToPerceptualSmooth);
-                }
-
-                // TODO: Smooth > Rough
-
-                // TODO: Rough > Smooth
-
-                // TODO: Smooth2 > Rough; Rough > Smooth2
-
-                // Emissive > EmissiveClipped
-                if (isOutputEmissiveClipped && graph.TryGetSources(EncodingChannel.Emissive, out sourceList)) {
+                // Emissive > *
+                if ((isOutputEmissiveClipped || isOutputEmissiveInverse) && graph.TryGetSources(EncodingChannel.Emissive, out sourceList)) {
                     foreach (var source in sourceList)
                         optionsMap.GetOrCreate(source.Tag, NewOptions).Set(source.Channel, color);
                 }
 
                 // EmissiveClipped > Emissive
-                if (isOutputEmissive && graph.TryGetSources(EncodingChannel.EmissiveClipped, out sourceList)) {
+                if ((isOutputEmissive || isOutputEmissiveInverse) && graph.TryGetSources(EncodingChannel.EmissiveClipped, out sourceList)) {
                     foreach (var source in sourceList)
-                        optionsMap.GetOrCreate(source.Tag, NewOptions).Set(source.Channel, color);
-
-                    filterOptions.Append(color, filter.EmissiveClippedToEmissive);
+                        optionsMap.GetOrCreate(source.Tag, NewOptions).Set(source.Channel, color, filter.EmissiveClippedToEmissive);
                 }
 
-                // Emissive > EmissiveInv
-                if (isOutputEmissiveInverse && graph.TryGetSources(EncodingChannel.Emissive, out sourceList)) {
+                // EmissiveInverse > Emissive
+                if ((isOutputEmissive || isOutputEmissiveClipped) && graph.TryGetSources(EncodingChannel.EmissiveInverse, out sourceList)) {
                     foreach (var source in sourceList)
-                        optionsMap.GetOrCreate(source.Tag, NewOptions).Set(source.Channel, color);
-                }
-
-                // EmissiveInv > Emissive
-                if (isOutputEmissive && graph.TryGetSources(EncodingChannel.EmissiveInverse, out sourceList)) {
-                    foreach (var source in sourceList)
-                        optionsMap.GetOrCreate(source.Tag, NewOptions).Set(source.Channel, color);
-
-                    filterOptions.Append(color, filter.Invert);
+                        optionsMap.GetOrCreate(source.Tag, NewOptions).Set(source.Channel, color, filter.Invert);
                 }
             }
         }

--- a/MC-PBR-Pipeline/Internal/Textures/TextureFilter.cs
+++ b/MC-PBR-Pipeline/Internal/Textures/TextureFilter.cs
@@ -19,9 +19,6 @@ namespace McPbrPipeline.Internal.Textures
         public void GenericScaleFilter(ref byte value, in float scale) =>
             value = MathEx.Saturate(value / 255d * scale);
 
-        //public void HeightScaleFilter(ref byte value) =>
-        //    value = MathEx.Saturate(1 - (1 - value / 255d) * texture.HeightScale);
-
         public void SmoothToPerceptualSmooth(ref byte value) =>
             value = MathEx.Saturate(Math.Sqrt(value / 255d));
 
@@ -54,10 +51,11 @@ namespace McPbrPipeline.Internal.Textures
         }
 
         private static readonly Dictionary<string, Func<PbrProperties, byte?>> valueMap = new Dictionary<string, Func<PbrProperties, byte?>>(StringComparer.InvariantCultureIgnoreCase) {
+            [EncodingChannel.Height] = tex => tex.HeightValue,
             [EncodingChannel.NormalX] = tex => tex.NormalValueX,
             [EncodingChannel.NormalY] = tex => tex.NormalValueY,
             [EncodingChannel.NormalZ] = tex => tex.NormalValueZ,
-            [EncodingChannel.Height] = tex => tex.HeightValue,
+            [EncodingChannel.Occlusion] = tex => tex.OcclusionValue,
             [EncodingChannel.Smooth] = tex => tex.SmoothValue,
             [EncodingChannel.PerceptualSmooth] = tex => tex.SmoothValue,
             [EncodingChannel.Rough] = tex => tex.RoughValue,
@@ -65,7 +63,6 @@ namespace McPbrPipeline.Internal.Textures
             [EncodingChannel.Emissive] = tex => tex.EmissiveValue,
             [EncodingChannel.EmissiveClipped] = tex => tex.EmissiveValue,
             [EncodingChannel.EmissiveInverse] = tex => tex.EmissiveValue,
-            [EncodingChannel.Occlusion] = tex => tex.OcclusionValue,
             [EncodingChannel.Porosity] = tex => tex.PorosityValue,
         };
 
@@ -75,15 +72,15 @@ namespace McPbrPipeline.Internal.Textures
             [EncodingChannel.AlbedoB] = t => t.AlbedoScaleB,
             [EncodingChannel.AlbedoA] = t => t.AlbedoScaleA,
             [EncodingChannel.Height] = t => t.HeightScale,
-            // AO
+            [EncodingChannel.Occlusion] = t => t.OcclusionScale,
             [EncodingChannel.Smooth] = t => t.SmoothScale,
             [EncodingChannel.PerceptualSmooth] = t => t.SmoothScale,
             [EncodingChannel.Rough] = t => t.RoughScale,
             [EncodingChannel.Metal] = t => t.MetalScale,
-            // Porosity-SSS
             [EncodingChannel.Emissive] = t => t.EmissiveScale,
             [EncodingChannel.EmissiveClipped] = t => t.EmissiveScale,
             [EncodingChannel.EmissiveInverse] = t => t.EmissiveScale,
+            // Porosity-SSS
         };
     }
 }

--- a/MC-PBR-Pipeline/MC-PBR-Pipeline.csproj
+++ b/MC-PBR-Pipeline/MC-PBR-Pipeline.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>0.2.0</Version>
+    <Version>0.2.1</Version>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>McPbrPipeline</RootNamespace>
     <AssemblyName>MCPBRP</AssemblyName>


### PR DESCRIPTION
- Smooth <> Perceptual Smooth conversion fix.
- Only create normal maps when missing normals.
- Support local `*.mcmeta` file publishing.
- Height value invert fix.
- Refactor and reduce to single image processor workflow.
- Simplify and ANSI color console logging.
- Do not resize in `/colormap` or `/misc` directories.